### PR TITLE
enabling unicode character, escape sequences, and keeping essential metadata

### DIFF
--- a/bin/nb-templater
+++ b/bin/nb-templater
@@ -4,6 +4,7 @@ import json
 import argparse
 import datetime
 import sys
+import os
 
 desc = """\
 A tool to generate a Python script that can generate a Jupyter
@@ -24,7 +25,7 @@ if len(sys.argv) == 1:
 filename = args.filename
 
 # Read in Jupyter notebook template file
-with open(filename, 'r') as file:
+with open(file=filename, mode='r', encoding='utf-8') as file:
     ipynb = json.load(file)
 
 nb_cells = []
@@ -40,6 +41,7 @@ now = datetime.datetime.now()
 datetime_now = now.strftime("%Y-%m-%d %H:%M %Z")
 
 output_header="""\
+# -*- coding: utf-8 -*-
 # `nb_templater` generated Python script
 # Generated from .ipynb template: {}
 # www.github.com/ismailuddin/jupyter-nb-templater/
@@ -50,9 +52,9 @@ import sys
 nb = nbf.v4.new_notebook() \n\n""".format(args.filename, datetime_now)
 
 cell_template_string = """\
-cell_{0}=\"\"\"\\
+cell_{0}=r\"\"\"
 {1}
-\"\"\"\n
+\"\"\".strip()\n
 """
 
 output_str += output_header
@@ -96,17 +98,20 @@ output_str += nb_cells_generator
 if args.nboutput:
     nb_output_name = args.nboutput 
 else:
-    nb_output_name = "_" + args.filename
+    nb_output_name = os.path.realpath(args.filename)
+    nb_output_base_name = "_" + os.path.basename(nb_output_name)
+    nb_output_dir = os.path.dirname(nb_output_name)
+    nb_output_name = os.path.join(nb_output_dir,nb_output_base_name)
 
 write_nb = """\n
-nbf.write(nb, '{0}')
-print("Jupyter notebook {0} successfully generated.")
+nbf.write(nb, r'{0}')
+print(r"Jupyter notebook {0} successfully generated.")
 """.format(nb_output_name)
 
 output_str += write_nb
 
 # Output Python script file
-with open(args.output, 'w') as output:
+with open(file=args.output, mode='w', encoding='utf-8') as output:
     output.write(output_str)
 
 print("Python script {} generated sucessfully.".format(args.output))

--- a/bin/nb-templater
+++ b/bin/nb-templater
@@ -35,7 +35,16 @@ output_str = ""
 for cell in ipynb['cells']:
     cell_type = cell['cell_type']
     source = cell['source']
-    nb_cells.append([cell_type, source])
+    old_metadata = cell['metadata']
+    metadata = {}
+    # it is not necessary to add all metadata
+    # metadata keys can be added here if needed
+    # add tags
+    if 'tags' in old_metadata:
+        tags = old_metadata['tags']
+        if tags:
+            metadata['tags'] = tags
+    nb_cells.append([cell_type, source, metadata])
 
 now = datetime.datetime.now()
 datetime_now = now.strftime("%Y-%m-%d %H:%M %Z")
@@ -86,7 +95,10 @@ for i, cell in enumerate(nb_cells):
         _cell = mdown_cell_str.format("cell_{}".format(i))
         _list_of_cells.append(_cell)
     elif cell[0] == 'code':
-        _cell = code_cell_str.format("cell_{}".format(i))
+        if cell[2]:
+            _cell = code_cell_str.format("source=cell_{},metadata={}".format(i,cell[2]))
+        else:
+            _cell = code_cell_str.format("cell_{}".format(i))
         _list_of_cells.append(_cell)
 
 list_of_cells = ',\n'.join(_list_of_cells)
@@ -94,6 +106,23 @@ list_of_cells = ',\n'.join(_list_of_cells)
 nb_cells_generator = nb_cells_generator_str.format(list_of_cells)
 
 output_str += nb_cells_generator
+
+# add metadata as if it was created with jupyter notebook
+# missing metadata may cause error when working with some CLI processes
+nb_metadata_generator_str = """
+nb['metadata'] = {}
+"""
+old_nb_metadata = ipynb['metadata']
+nb_metadata = {}
+# add kernelspec if any
+if 'kernelspec' in old_nb_metadata:
+    kernelspec = old_nb_metadata['kernelspec']
+    if kernelspec:
+        nb_metadata['kernelspec'] = kernelspec
+
+if nb_metadata:
+    nb_metadata_generator = nb_metadata_generator_str.format(nb_metadata)
+    output_str += nb_metadata_generator
 
 if args.nboutput:
     nb_output_name = args.nboutput 


### PR DESCRIPTION
Hi, I have made some additional changes to your code, I think it's nice to have

1) enable unicode characters and escape sequences if any within content of jupyter notebook (this is real problem I have encountered when working with accented character in my tongue language, vietnames)
2) reserve metadata on intention, e.g. some programs like papermill require tags and kernelspec metadata to functionate

Thank you very much !